### PR TITLE
fix: gate linux-only wheel in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pydantic
 pydantic_settings
 transformers~=4.38.2
 websockets
-https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.6/flash_attn-2.5.6+cu122torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
+https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.6/flash_attn-2.5.6+cu122torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl ; sys_platform == "linux" and python_version == "3.10"


### PR DESCRIPTION
## Summary
- add an environment marker to the Linux-only lash-attn wheel entry in equirements.txt`n- align the plain requirements file with the existing platform-conditioned intent in Pipfile`n
## Verification
- python -m pip install -r requirements.txt --dry-run`n- confirmed the Linux-only wheel is skipped on Windows

## Scope
- installer metadata only
- no runtime logic changes